### PR TITLE
Bump the npm_and_yarn group across 25 directories with 1 update

### DIFF
--- a/basic-assignment-1-lisa-solution/package-lock.json
+++ b/basic-assignment-1-lisa-solution/package-lock.json
@@ -40,7 +40,7 @@
         "karma-jasmine": "~5.1.0",
         "karma-jasmine-html-reporter": "~2.0.0",
         "npm": "^9.8.0",
-        "postcss": ">=8.4.32",
+        "postcss": ">=8.4.33",
         "typescript": "~4.9.4",
         "webpack": ">=5.76.0"
       }
@@ -12832,9 +12832,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.32",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.32.tgz",
-      "integrity": "sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==",
+      "version": "8.4.33",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.33.tgz",
+      "integrity": "sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==",
       "dev": true,
       "funding": [
         {

--- a/basic-assignment-1-lisa-solution/package.json
+++ b/basic-assignment-1-lisa-solution/package.json
@@ -26,7 +26,7 @@
     "tslib": "^2.3.0",
     "webpack": ">=5.76.0",
     "zone.js": "~0.13.1",
-    "postcss": ">=8.4.32"
+    "postcss": ">=8.4.33"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^15.2.9",
@@ -45,6 +45,6 @@
     "npm": "^9.8.0",
     "typescript": "~4.9.4",
     "webpack": ">=5.76.0",
-    "postcss": ">=8.4.32"
+    "postcss": ">=8.4.33"
   }
 }

--- a/basic-assignment-2-lisa-solution-3/package-lock.json
+++ b/basic-assignment-2-lisa-solution-3/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "basic-assignment-2-lisa-solution-3",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "basic-assignment-2-lisa-solution-3",
-      "version": "0.1.0",
+      "version": "0.0.0",
       "dependencies": {
         "@angular/animations": "^15.2.9",
         "@angular/common": "^15.2.9",
@@ -21,8 +21,7 @@
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "webpack": ">=5.76.0",
-        "zone.js": "~0.13.1",
-        "postcss": ">=8.4.31"
+        "zone.js": "~0.13.1"
       },
       "devDependencies": {
         "@angular-devkit/build-angular": "^15.2.9",
@@ -37,9 +36,9 @@
         "karma-coverage": "~2.2.0",
         "karma-jasmine": "~5.1.0",
         "karma-jasmine-html-reporter": "~2.0.0",
+        "postcss": ">=8.4.31",
         "typescript": "~4.9.4",
-        "webpack": ">=5.76.0",
-        "postcss": ">=8.4.31"
+        "webpack": ">=5.76.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -425,6 +424,30 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
+    },
+    "node_modules/@angular-devkit/build-angular/node_modules/postcss": {
+      "version": "8.4.21",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
+      "integrity": "sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.4",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
     },
     "node_modules/@angular-devkit/build-angular/node_modules/rxjs": {
       "version": "6.6.7",
@@ -9658,9 +9681,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.21",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
-      "integrity": "sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==",
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
       "dev": true,
       "funding": [
         {
@@ -9670,10 +9693,14 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.4",
+        "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       },

--- a/basics-components/package-lock.json
+++ b/basics-components/package-lock.json
@@ -36,7 +36,7 @@
         "karma-coverage": "~2.2.0",
         "karma-jasmine": "~5.1.0",
         "karma-jasmine-html-reporter": "~2.0.0",
-        "postcss": ">=8.4.31",
+        "postcss": ">=8.4.32",
         "typescript": "~4.9.4",
         "webpack": ">=5.76.0"
       }
@@ -8716,9 +8716,9 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
       "dev": true,
       "funding": [
         {
@@ -9681,9 +9681,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.4.32",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.32.tgz",
+      "integrity": "sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==",
       "dev": true,
       "funding": [
         {
@@ -9700,7 +9700,7 @@
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.6",
+        "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       },

--- a/basics-components/package.json
+++ b/basics-components/package.json
@@ -24,7 +24,7 @@
     "tslib": "^2.3.0",
     "webpack": ">=5.76.0",
     "zone.js": "~0.13.1",
-    "postcss": ">=8.4.31"
+    "postcss": ">=8.4.32"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^15.2.9",
@@ -41,6 +41,6 @@
     "karma-jasmine-html-reporter": "~2.0.0",
     "typescript": "~4.9.4",
     "webpack": ">=5.76.0",
-    "postcss": ">=8.4.31"
+    "postcss": ">=8.4.32"
   }
 }


### PR DESCRIPTION
Bumps the npm_and_yarn group with 1 update in the /basic-assignment-1-lisa-solution directory: [postcss](https://github.com/postcss/postcss).
Bumps the npm_and_yarn group with 1 update in the /basic-assignment-2-lisa-solution-3 directory: [postcss](https://github.com/postcss/postcss).
Bumps the npm_and_yarn group with 1 update in the /basics-components directory: [postcss](https://github.com/postcss/postcss).


Updates `postcss` from 8.4.32 to 8.4.33
- [Release notes](https://github.com/postcss/postcss/releases)
- [Changelog](https://github.com/postcss/postcss/blob/main/CHANGELOG.md)
- [Commits](https://github.com/postcss/postcss/compare/8.4.32...8.4.33)

Updates `postcss` from 8.4.21 to 8.4.31
- [Release notes](https://github.com/postcss/postcss/releases)
- [Changelog](https://github.com/postcss/postcss/blob/main/CHANGELOG.md)
- [Commits](https://github.com/postcss/postcss/compare/8.4.32...8.4.33)

Updates `postcss` from 8.4.31 to 8.4.32
- [Release notes](https://github.com/postcss/postcss/releases)
- [Changelog](https://github.com/postcss/postcss/blob/main/CHANGELOG.md)
- [Commits](https://github.com/postcss/postcss/compare/8.4.32...8.4.33)

---
updated-dependencies:
- dependency-name: postcss dependency-type: direct:production dependency-group: npm_and_yarn-security-group
- dependency-name: postcss dependency-type: direct:production dependency-group: npm_and_yarn-security-group
- dependency-name: postcss dependency-type: direct:production dependency-group: npm_and_yarn-security-group ...