### PR TITLE
Bump the npm_and_yarn group across 25 directories with 1 update

### DIFF
--- a/basic-assignment-1-lisa-solution/package-lock.json
+++ b/basic-assignment-1-lisa-solution/package-lock.json
@@ -23,8 +23,7 @@
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "webpack": ">=5.76.0",
-        "zone.js": "~0.13.1",
-        "postcss": ">=8.4.31"
+        "zone.js": "~0.13.1"
       },
       "devDependencies": {
         "@angular-devkit/build-angular": "^15.2.9",
@@ -41,9 +40,9 @@
         "karma-jasmine": "~5.1.0",
         "karma-jasmine-html-reporter": "~2.0.0",
         "npm": "^9.8.0",
+        "postcss": ">=8.4.31",
         "typescript": "~4.9.4",
-        "webpack": ">=5.76.0",
-        "postcss": ">=8.4.31"
+        "webpack": ">=5.76.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -429,6 +428,30 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
+    },
+    "node_modules/@angular-devkit/build-angular/node_modules/postcss": {
+      "version": "8.4.21",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
+      "integrity": "sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.4",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
     },
     "node_modules/@angular-devkit/build-angular/node_modules/rxjs": {
       "version": "6.6.7",
@@ -12809,9 +12832,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.21",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
-      "integrity": "sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==",
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
       "dev": true,
       "funding": [
         {
@@ -12821,10 +12844,14 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.4",
+        "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       },


### PR DESCRIPTION
Bumps the npm_and_yarn group with 1 update in the /basic-assignment-1-lisa-solution directory: [postcss](https://github.com/postcss/postcss).


Updates `postcss` from 8.4.21 to 8.4.31
- [Release notes](https://github.com/postcss/postcss/releases)
- [Changelog](https://github.com/postcss/postcss/blob/main/CHANGELOG.md)
- [Commits](https://github.com/postcss/postcss/compare/8.4.21...8.4.31)

---
updated-dependencies:
- dependency-name: postcss dependency-type: direct:production dependency-group: npm_and_yarn-security-group ...