### PR TITLE
Bump the npm_and_yarn group across 25 directories with 1 update

### DIFF
--- a/basic-assignment-1-lisa-solution/package-lock.json
+++ b/basic-assignment-1-lisa-solution/package-lock.json
@@ -40,7 +40,7 @@
         "karma-jasmine": "~5.1.0",
         "karma-jasmine-html-reporter": "~2.0.0",
         "npm": "^9.8.0",
-        "postcss": ">=8.4.31",
+        "postcss": ">=8.4.32",
         "typescript": "~4.9.4",
         "webpack": ">=5.76.0"
       }
@@ -8756,9 +8756,9 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
       "dev": true,
       "funding": [
         {
@@ -12832,9 +12832,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.4.32",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.32.tgz",
+      "integrity": "sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==",
       "dev": true,
       "funding": [
         {
@@ -12851,7 +12851,7 @@
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.6",
+        "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       },

--- a/basic-assignment-1-lisa-solution/package.json
+++ b/basic-assignment-1-lisa-solution/package.json
@@ -26,7 +26,7 @@
     "tslib": "^2.3.0",
     "webpack": ">=5.76.0",
     "zone.js": "~0.13.1",
-    "postcss": ">=8.4.31"
+    "postcss": ">=8.4.32"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^15.2.9",
@@ -45,6 +45,6 @@
     "npm": "^9.8.0",
     "typescript": "~4.9.4",
     "webpack": ">=5.76.0",
-    "postcss": ">=8.4.31"
+    "postcss": ">=8.4.32"
   }
 }


### PR DESCRIPTION
Bumps the npm_and_yarn group with 1 update in the /basic-assignment-1-lisa-solution directory: [postcss](https://github.com/postcss/postcss).


Updates `postcss` from 8.4.31 to 8.4.32
- [Release notes](https://github.com/postcss/postcss/releases)
- [Changelog](https://github.com/postcss/postcss/blob/main/CHANGELOG.md)
- [Commits](https://github.com/postcss/postcss/compare/8.4.31...8.4.32)

---
updated-dependencies:
- dependency-name: postcss dependency-type: direct:production dependency-group: npm_and_yarn-security-group ...