### PR TITLE
Bump the npm_and_yarn group across 24 directories with 1 update

### DIFF
--- a/basic-assignment-3-lisa-solution/package-lock.json
+++ b/basic-assignment-3-lisa-solution/package-lock.json
@@ -35,7 +35,7 @@
         "karma-jasmine": "~5.1.0",
         "karma-jasmine-html-reporter": "~2.0.0",
         "npm": "^9.8.0",
-        "postcss": ">=8.4.31",
+        "postcss": ">=8.4.32",
         "typescript": "~4.9.4",
         "webpack": ">=5.76.0"
       }
@@ -8743,9 +8743,9 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
       "dev": true,
       "funding": [
         {
@@ -12819,9 +12819,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.4.32",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.32.tgz",
+      "integrity": "sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==",
       "dev": true,
       "funding": [
         {
@@ -12838,7 +12838,7 @@
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.6",
+        "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       },

--- a/basic-assignment-3-lisa-solution/package.json
+++ b/basic-assignment-3-lisa-solution/package.json
@@ -20,7 +20,7 @@
     "@angular/router": "^15.2.9",
     "bootstrap": "^5.3.0",
     "webpack": ">=5.76.0",
-    "postcss": ">=8.4.31",
+    "postcss": ">=8.4.32",
     "rxjs": "~7.8.1",
     "tslib": "^2.5.3",
     "zone.js": "~0.13.1"
@@ -39,7 +39,7 @@
     "karma-jasmine-html-reporter": "~2.0.0",
     "npm": "^9.8.0",
     "webpack": ">=5.76.0",
-    "postcss": ">=8.4.31",
+    "postcss": ">=8.4.32",
     "typescript": "~4.9.4"
   }
 }

--- a/outputting-lists-with-ngFor/package-lock.json
+++ b/outputting-lists-with-ngFor/package-lock.json
@@ -38,7 +38,7 @@
         "karma-coverage": "~2.2.0",
         "karma-jasmine": "~5.1.0",
         "karma-jasmine-html-reporter": "~2.0.0",
-        "postcss": ">=8.4.31",
+        "postcss": ">=8.4.32",
         "typescript": "~4.9.4",
         "webpack": ">=5.76.0"
       }
@@ -8761,9 +8761,9 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
       "dev": true,
       "funding": [
         {
@@ -9726,9 +9726,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.4.32",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.32.tgz",
+      "integrity": "sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==",
       "dev": true,
       "funding": [
         {
@@ -9745,7 +9745,7 @@
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.6",
+        "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       },

--- a/outputting-lists-with-ngFor/package.json
+++ b/outputting-lists-with-ngFor/package.json
@@ -25,7 +25,7 @@
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "webpack": ">=5.76.0",
-    "postcss": ">=8.4.31",
+    "postcss": ">=8.4.32",
     "zone.js": "~0.13.1"
   },
   "devDependencies": {
@@ -43,6 +43,6 @@
     "karma-jasmine-html-reporter": "~2.0.0",
     "typescript": "~4.9.4",
     "webpack": ">=5.76.0",
-    "postcss": ">=8.4.31"
+    "postcss": ">=8.4.32"
   }
 }

--- a/prj-start-d/package-lock.json
+++ b/prj-start-d/package-lock.json
@@ -44,7 +44,7 @@
         "karma-coverage": "~2.2.0",
         "karma-jasmine": "~5.1.0",
         "karma-jasmine-html-reporter": "~2.0.0",
-        "postcss": ">=8.4.31",
+        "postcss": ">=8.4.32",
         "typescript": "~4.9.4",
         "vite": ">=4.5.2",
         "webpack": ">=5.76.0"
@@ -9601,9 +9601,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.4.32",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.32.tgz",
+      "integrity": "sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==",
       "dev": true,
       "funding": [
         {
@@ -9620,7 +9620,7 @@
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.6",
+        "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       },
@@ -11573,7 +11573,7 @@
       "dev": true,
       "dependencies": {
         "esbuild": "^0.19.3",
-        "postcss": "^8.4.32",
+        "postcss": ">=8.4.32",
         "rollup": "^4.2.0"
       },
       "bin": {

--- a/prj-start-d/package.json
+++ b/prj-start-d/package.json
@@ -26,7 +26,7 @@
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "webpack": ">=5.76.0",
-    "postcss": ">=8.4.31",
+    "postcss": ">=8.4.32",
     "zone.js": "~0.13.1",
     "vite": ">=4.5.2",
     "critters": ">=0.0.20"
@@ -48,7 +48,7 @@
     "karma-jasmine-html-reporter": "~2.0.0",
     "typescript": "~4.9.4",
     "webpack": ">=5.76.0",
-    "postcss": ">=8.4.31",
+    "postcss": ">=8.4.32",
     "vite": ">=4.5.2",
     "critters": ">=0.0.20"
   }


### PR DESCRIPTION
Bumps the npm_and_yarn group with 1 update in the /basic-assignment-3-lisa-solution directory: [postcss](https://github.com/postcss/postcss).
Bumps the npm_and_yarn group with 1 update in the /outputting-lists-with-ngFor directory: [postcss](https://github.com/postcss/postcss).
Bumps the npm_and_yarn group with 1 update in the /prj-start-d directory: [postcss](https://github.com/postcss/postcss).


Updates `postcss` from 8.4.31 to 8.4.32
- [Release notes](https://github.com/postcss/postcss/releases)
- [Changelog](https://github.com/postcss/postcss/blob/main/CHANGELOG.md)
- [Commits](https://github.com/postcss/postcss/compare/8.4.31...8.4.32)

Updates `postcss` from 8.4.31 to 8.4.32
- [Release notes](https://github.com/postcss/postcss/releases)
- [Changelog](https://github.com/postcss/postcss/blob/main/CHANGELOG.md)
- [Commits](https://github.com/postcss/postcss/compare/8.4.31...8.4.32)

Updates `postcss` from 8.4.31 to 8.4.32
- [Release notes](https://github.com/postcss/postcss/releases)
- [Changelog](https://github.com/postcss/postcss/blob/main/CHANGELOG.md)
- [Commits](https://github.com/postcss/postcss/compare/8.4.31...8.4.32)

---
updated-dependencies:
- dependency-name: postcss dependency-type: direct:production dependency-group: npm_and_yarn-security-group
- dependency-name: postcss dependency-type: direct:production dependency-group: npm_and_yarn-security-group
- dependency-name: postcss dependency-type: direct:production dependency-group: npm_and_yarn-security-group ...